### PR TITLE
Support Windows 10 and Windows 11 at the same time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ windows = { version = "0.52", features = [
     # Find WinApi features with searching here https://microsoft.github.io/windows-docs-rs/
     "implement",
     "Win32_System_Com",
-    "Win32_UI_Shell_Common",        # for IObjectArray
-    "Win32_UI_WindowsAndMessaging", # for TranslateMessage etc.
-    "Win32_Foundation",             # for FindWindowW
-    "Win32_System_Threading",       # For CreateThread
+    "Win32_UI_Shell_Common",          # for IObjectArray
+    "Win32_UI_WindowsAndMessaging",   # for TranslateMessage etc.
+    "Win32_Foundation",               # for FindWindowW
+    "Win32_System_Threading",         # For CreateThread
+    "Win32_System_SystemInformation", # For RtlGetVersion return type
+    "Wdk_System_SystemServices",      # For RtlGetVersion
 ] }
 windows-interface = { version = "0.52" }
 windows-implement = { version = "0.52" }

--- a/dll/src/lib.rs
+++ b/dll/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![allow(non_snake_case, clippy::not_unsafe_ptr_arg_deref)]
 
 use once_cell::sync::Lazy;
 use std::{
@@ -40,7 +40,7 @@ pub extern "C" fn GetDesktopIdByNumber(number: i32) -> GUID {
 
 #[no_mangle]
 pub extern "C" fn GetDesktopNumberById(desktop_id: GUID) -> i32 {
-    get_desktop(&desktop_id)
+    get_desktop(desktop_id)
         .get_index()
         .map_or(-1, |x| x as i32)
 }
@@ -120,23 +120,20 @@ pub extern "C" fn RegisterPostMessageHook(listener_hwnd: HWND, message_offset: u
             log::log_output("RegisterPostMessageHook: create new threads");
             let listener_thread = std::thread::spawn(move || {
                 for item in rx {
-                    match item {
-                        DesktopEvent::DesktopChanged { new, old } => {
-                            let new_index = new.get_index().unwrap_or(0);
-                            let old_index = old.get_index().unwrap_or(0);
-                            let a = LISTENER_HWNDS.lock().unwrap();
-                            for hwnd in a.iter() {
-                                unsafe {
-                                    let _ = PostMessageW(
-                                        HWND(*hwnd as isize),
-                                        message_offset,
-                                        WPARAM(old_index as usize),
-                                        LPARAM(new_index as isize),
-                                    );
-                                }
+                    if let DesktopEvent::DesktopChanged { new, old } = item {
+                        let new_index = new.get_index().unwrap_or(0);
+                        let old_index = old.get_index().unwrap_or(0);
+                        let a = LISTENER_HWNDS.lock().unwrap();
+                        for hwnd in a.iter() {
+                            unsafe {
+                                let _ = PostMessageW(
+                                    HWND(*hwnd),
+                                    message_offset,
+                                    WPARAM(old_index as usize),
+                                    LPARAM(new_index as isize),
+                                );
                             }
                         }
-                        _ => (),
                     }
                 }
             });

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -1,5 +1,3 @@
-use crate::interfaces::ComIn;
-
 use super::comobjects::*;
 use super::{interfaces::IVirtualDesktop, *};
 use std::{convert::TryFrom, fmt::Debug};
@@ -78,54 +76,47 @@ impl TryFrom<IVirtualDesktop> for Desktop {
         Ok(Desktop(DesktopInternal::try_from(&desktop)?))
     }
 }
-impl<'a> TryFrom<&'a ComIn<'a, IVirtualDesktop>> for Desktop {
+impl<'a> TryFrom<&'a IVirtualDesktop> for Desktop {
     type Error = Error;
 
-    fn try_from(desktop: &'a ComIn<'a, IVirtualDesktop>) -> Result<Self> {
+    fn try_from(desktop: &'a IVirtualDesktop) -> Result<Self> {
         Ok(Desktop(DesktopInternal::try_from(desktop)?))
-    }
-}
-impl<'a> TryFrom<ComIn<'a, IVirtualDesktop>> for Desktop {
-    type Error = Error;
-
-    fn try_from(desktop: ComIn<'a, IVirtualDesktop>) -> Result<Self> {
-        Ok(Desktop(DesktopInternal::try_from(&desktop)?))
     }
 }
 impl Desktop {
     /// Get the GUID of the desktop
     pub fn get_id(&self) -> Result<GUID> {
-        let internal = self.0.clone();
+        let internal = self.0;
         with_com_objects(move |o| o.get_desktop_id(&internal))
     }
 
     pub fn get_index(&self) -> Result<u32> {
-        let internal = self.0.clone();
+        let internal = self.0;
         with_com_objects(move |o| o.get_desktop_index(&internal))
     }
 
     /// Get desktop name
     pub fn get_name(&self) -> Result<String> {
-        let internal = self.0.clone();
+        let internal = self.0;
         with_com_objects(move |o| o.get_desktop_name(&internal))
     }
 
     /// Set desktop name
     pub fn set_name(&self, name: &str) -> Result<()> {
-        let internal = self.0.clone();
+        let internal = self.0;
         let name_ = name.to_owned();
         with_com_objects(move |o| o.set_desktop_name(&internal, &name_))
     }
 
     /// Get desktop wallpaper path
     pub fn get_wallpaper(&self) -> Result<String> {
-        let internal = self.0.clone();
+        let internal = self.0;
         with_com_objects(move |o| o.get_desktop_wallpaper(&internal))
     }
 
     /// Set desktop wallpaper path
     pub fn set_wallpaper(&self, path: &str) -> Result<()> {
-        let internal = self.0.clone();
+        let internal = self.0;
         let path_ = path.to_owned();
         with_com_objects(move |o| o.set_desktop_wallpaper(&internal, &path_))
     }
@@ -181,7 +172,7 @@ where
     T: Into<Desktop>,
     T: Send + 'static + Copy,
 {
-    let hwnd = hwnd.clone();
+    let hwnd = *hwnd;
     with_com_objects(move |o| o.move_window_to_desktop(&hwnd, &desktop.into().into()))
 }
 

--- a/src/interfaces.rs
+++ b/src/interfaces.rs
@@ -1,46 +1,56 @@
-/// Interface definitions for the Virtual Desktop API
-///
-/// Most of the functions are not tested or used, beware if you try to use these
-/// for something else. Notably I know that most out parameters defined as `*mut
-/// IMyObject` are incorrect, they probably should be *mut Option<IMyObject>.
-///
-/// Generally these are the rules:
-/// 1. InOpt = `Option<ComIn<IMyObject>>` or `Option<ManuallyDrop<IMyObject>>`
-/// 2. In = `ComIn<IMyObject>` or `ManuallyDrop<IMyObject>`
-/// 3. Out = `*mut Option<IMyObject>`
-/// 4. OutOpt = `*mut Option<IMyObject>`
-///
-/// Last two are same intentionally.
-///
-/// ## The summary of COM object lifetime rules:
-///
-/// > 1. When a COM object is passed from caller to callee as an input parameter
-/// >    to a method, the caller is expected to keep a reference on the object
-/// >    for the duration of the method call. The callee shouldn't need to call
-/// >    `AddRef` or `Release` for the synchronous duration of that method call.
-/// >
-/// > 2. When a COM object is passed from callee to caller as an out parameter
-/// >    from a method the object is provided to the caller with a reference
-/// >    already taken and the caller owns the reference. Which is to say, it is
-/// >    the caller's responsibility to call `Release` when they're done with
-/// >    the object.
-/// >
-/// > 3. When making a copy of a COM object pointer you need to call `AddRef`
-/// >    and `Release`. The `AddRef` must be called before you call `Release` on
-/// >    the original COM object pointer.
-///
-/// Rules as [written by David
-/// Risney](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2133).
-///
-/// If you read the rules carefully, ComIn is most common usecase in Rust
-/// API definitions as most parameters are `In` parameters.
-#[allow(non_upper_case_globals)]
+//! Interface definitions for the Virtual Desktop API
+//!
+//! Most of the functions are not tested or used, beware if you try to use these
+//! for something else. Notably I know that most out parameters defined as `*mut
+//! IMyObject` are incorrect, they probably should be *mut Option<IMyObject>.
+//!
+//! Generally these are the rules:
+//! 1. InOpt = `Option<ComIn<IMyObject>>` or `Option<ManuallyDrop<IMyObject>>`
+//! 2. In = `ComIn<IMyObject>` or `ManuallyDrop<IMyObject>`
+//! 3. Out = `*mut Option<IMyObject>`
+//! 4. OutOpt = `*mut Option<IMyObject>`
+//!
+//! Last two are same intentionally.
+//!
+//! ## The summary of COM object lifetime rules:
+//!
+//! > 1. When a COM object is passed from caller to callee as an input parameter
+//! >    to a method, the caller is expected to keep a reference on the object
+//! >    for the duration of the method call. The callee shouldn't need to call
+//! >    `AddRef` or `Release` for the synchronous duration of that method call.
+//! >
+//! > 2. When a COM object is passed from callee to caller as an out parameter
+//! >    from a method the object is provided to the caller with a reference
+//! >    already taken and the caller owns the reference. Which is to say, it is
+//! >    the caller's responsibility to call `Release` when they're done with
+//! >    the object.
+//! >
+//! > 3. When making a copy of a COM object pointer you need to call `AddRef`
+//! >    and `Release`. The `AddRef` must be called before you call `Release` on
+//! >    the original COM object pointer.
+//!
+//! Rules as [written by David
+//! Risney](https://github.com/MicrosoftEdge/WebView2Feedback/issues/2133).
+//!
+//! If you read the rules carefully, ComIn is most common usecase in Rust
+//! API definitions as most parameters are `In` parameters.
+#![allow(non_upper_case_globals, clippy::upper_case_acronyms)]
+
 use std::ffi::c_void;
 use std::ops::Deref;
 use windows::{
     core::{ComInterface, IUnknown, IUnknown_Vtbl, GUID, HRESULT, HSTRING},
     Win32::{Foundation::HWND, UI::Shell::Common::IObjectArray},
 };
+
+// Different versions of Windows have slightly different interfaces:
+mod build_10240;
+mod build_22000;
+mod build_dyn;
+
+// We only consume the COM interfaces in a way where we don't depend on the
+// exact Windows version:
+pub use build_dyn::*;
 
 /// ComIn is a wrapper for COM objects that are passed as input parameters. It
 /// allows to keep the life of the COM object for the duration of the function
@@ -99,42 +109,27 @@ impl<'a, T: ComInterface> ComIn<'a, T> {
 impl<'a, T: ComInterface> Deref for ComIn<'a, T> {
     type Target = T;
     fn deref(&self) -> &Self::Target {
-        unsafe { std::mem::transmute(&self.data) }
+        // Safety: A ComInterface type `T` is just a transparent type over a raw pointer
+        unsafe { &*(&self.data as *const *mut c_void as *const T) }
     }
 }
 
 #[allow(non_upper_case_globals)]
-pub const CLSID_ImmersiveShell: GUID = GUID {
-    data1: 0xC2F03A33,
-    data2: 0x21F5,
-    data3: 0x47FA,
-    data4: [0xB4, 0xBB, 0x15, 0x63, 0x62, 0xA2, 0xF2, 0x39],
-};
+pub const CLSID_ImmersiveShell: GUID = GUID::from_u128(0xC2F03A33_21F5_47FA_B4BB_156362A2F239);
 
 #[allow(dead_code)]
 #[allow(non_upper_case_globals)]
-pub const CLSID_IVirtualNotificationService: GUID = GUID {
-    data1: 0xA501FDEC,
-    data2: 0x4A09,
-    data3: 0x464C,
-    data4: [0xAE, 0x4E, 0x1B, 0x9C, 0x21, 0xB8, 0x49, 0x18],
-};
+pub const CLSID_IVirtualNotificationService: GUID =
+    GUID::from_u128(0xA501FDEC_4A09_464C_AE4E_1B9C21B84918);
 
 #[allow(non_upper_case_globals)]
-pub const CLSID_VirtualDesktopManagerInternal: GUID = GUID {
-    data1: 0xC5E0CDCA,
-    data2: 0x7B6E,
-    data3: 0x41B2,
-    data4: [0x9F, 0xC4, 0xD9, 0x39, 0x75, 0xCC, 0x46, 0x7B],
-};
+pub const CLSID_VirtualDesktopManagerInternal: GUID =
+    GUID::from_u128(0xC5E0CDCA_7B6E_41B2_9FC4_D93975CC467B);
 
 #[allow(non_upper_case_globals)]
-pub const CLSID_VirtualDesktopPinnedApps: GUID = GUID {
-    data1: 0xb5a399e7,
-    data2: 0x1c87,
-    data3: 0x46b8,
-    data4: [0x88, 0xe9, 0xfc, 0x57, 0x47, 0xb1, 0x71, 0xbd],
-};
+pub const CLSID_VirtualDesktopPinnedApps: GUID =
+    GUID::from_u128(0xb5a399e7_1c87_46b8_88e9_fc5747b171bd);
+
 type BOOL = i32;
 type DWORD = u32;
 type INT = i32;
@@ -159,6 +154,7 @@ type APPLICATION_VIEW_COMPATIBILITY_POLICY = UINT;
 type APPLICATION_VIEW_CLOAK_TYPE = UINT;
 
 #[allow(dead_code)]
+#[repr(C)]
 pub struct RECT {
     left: LONG,
     top: LONG,
@@ -167,10 +163,13 @@ pub struct RECT {
 }
 
 #[allow(dead_code)]
+#[repr(C)]
 pub struct SIZE {
     cx: LONG,
     cy: LONG,
 }
+
+// These COM interfaces are not different between different Windows versions:
 
 #[windows_interface::interface("6D5140C1-7436-11CE-8034-00AA006009FA")]
 pub unsafe trait IServiceProvider: IUnknown {
@@ -205,312 +204,4 @@ pub unsafe trait IVirtualDesktopManager: IUnknown {
         top_level_window: HWND,
         desktop_id: *const GUID,
     ) -> HRESULT;
-}
-
-#[windows_interface::interface("372E1D3B-38D3-42E4-A15B-8AB2B178F513")]
-pub unsafe trait IApplicationView: IUnknown {
-    /* IInspecateble */
-    pub unsafe fn get_iids(
-        &self,
-        out_iid_count: *mut ULONG,
-        out_opt_iid_array_ptr: *mut *mut GUID,
-    ) -> HRESULT;
-    pub unsafe fn get_runtime_class_name(&self, out_opt_class_name: *mut HSTRING) -> HRESULT;
-    pub unsafe fn get_trust_level(&self, ptr_trust_level: LPVOID) -> HRESULT;
-
-    /* IApplicationView methods */
-    pub unsafe fn set_focus(&self) -> HRESULT;
-    pub unsafe fn switch_to(&self) -> HRESULT;
-
-    pub unsafe fn try_invoke_back(&self, ptr_async_callback: IAsyncCallback) -> HRESULT;
-    pub unsafe fn get_thumbnail_window(&self, out_hwnd: *mut HWND) -> HRESULT;
-    pub unsafe fn get_monitor(&self, out_monitors: *mut *mut IImmersiveMonitor) -> HRESULT;
-    pub unsafe fn get_visibility(&self, out_int: LPVOID) -> HRESULT;
-    pub unsafe fn set_cloak(
-        &self,
-        application_view_cloak_type: APPLICATION_VIEW_CLOAK_TYPE,
-        unknown: INT,
-    ) -> HRESULT;
-    pub unsafe fn get_position(
-        &self,
-        unknowniid: *const GUID,
-        unknown_array_ptr: LPVOID,
-    ) -> HRESULT;
-    pub unsafe fn set_position(&self, view_position: *mut IApplicationViewPosition) -> HRESULT;
-    pub unsafe fn insert_after_window(&self, window: HWND) -> HRESULT;
-    pub unsafe fn get_extended_frame_position(&self, rect: *mut RECT) -> HRESULT;
-    pub unsafe fn get_app_user_model_id(&self, id: *mut PWSTR) -> HRESULT; // Proc17
-    pub unsafe fn set_app_user_model_id(&self, id: PCWSTR) -> HRESULT;
-    pub unsafe fn is_equal_by_app_user_model_id(&self, id: PCWSTR, out_result: *mut INT)
-        -> HRESULT;
-
-    /*** IApplicationView methods ***/
-    pub unsafe fn get_view_state(&self, out_state: *mut UINT) -> HRESULT; // Proc20
-    pub unsafe fn set_view_state(&self, state: UINT) -> HRESULT; // Proc21
-    pub unsafe fn get_neediness(&self, out_neediness: *mut INT) -> HRESULT; // Proc22
-    pub unsafe fn get_last_activation_timestamp(&self, out_timestamp: *mut ULONGLONG) -> HRESULT;
-    pub unsafe fn set_last_activation_timestamp(&self, timestamp: ULONGLONG) -> HRESULT;
-    pub unsafe fn get_virtual_desktop_id(&self, out_desktop_guid: *mut GUID) -> HRESULT;
-    pub unsafe fn set_virtual_desktop_id(&self, desktop_guid: *const GUID) -> HRESULT;
-    pub unsafe fn get_show_in_switchers(&self, out_show: *mut INT) -> HRESULT;
-    pub unsafe fn set_show_in_switchers(&self, show: INT) -> HRESULT;
-    pub unsafe fn get_scale_factor(&self, out_scale_factor: *mut INT) -> HRESULT;
-    pub unsafe fn can_receive_input(&self, out_can: *mut BOOL) -> HRESULT;
-    pub unsafe fn get_compatibility_policy_type(
-        &self,
-        out_policy_type: *mut APPLICATION_VIEW_COMPATIBILITY_POLICY,
-    ) -> HRESULT;
-    pub unsafe fn set_compatibility_policy_type(
-        &self,
-        policy_type: APPLICATION_VIEW_COMPATIBILITY_POLICY,
-    ) -> HRESULT;
-
-    pub unsafe fn get_size_constraints(
-        &self,
-        monitor: *mut IImmersiveMonitor,
-        out_size1: *mut SIZE,
-        out_size2: *mut SIZE,
-    ) -> HRESULT;
-    pub unsafe fn get_size_constraints_for_dpi(
-        &self,
-        dpi: UINT,
-        out_size1: *mut SIZE,
-        out_size2: *mut SIZE,
-    ) -> HRESULT;
-    pub unsafe fn set_size_constraints_for_dpi(
-        &self,
-        dpi: *const UINT,
-        size1: *const SIZE,
-        size2: *const SIZE,
-    ) -> HRESULT;
-
-    pub unsafe fn on_min_size_preferences_updated(&self, window: HWND) -> HRESULT;
-    pub unsafe fn apply_operation(&self, operation: *mut IApplicationViewOperation) -> HRESULT;
-    pub unsafe fn is_tray(&self, out_is: *mut BOOL) -> HRESULT;
-    pub unsafe fn is_in_high_zorder_band(&self, out_is: *mut BOOL) -> HRESULT;
-    pub unsafe fn is_splash_screen_presented(&self, out_is: *mut BOOL) -> HRESULT;
-    pub unsafe fn flash(&self) -> HRESULT;
-    pub unsafe fn get_root_switchable_owner(&self, app_view: *mut IApplicationView) -> HRESULT; // proc45
-    pub unsafe fn enumerate_ownership_tree(&self, objects: *mut IObjectArray) -> HRESULT; // proc46
-
-    pub unsafe fn get_enterprise_id(&self, out_id: *mut PWSTR) -> HRESULT; // proc47
-    pub unsafe fn is_mirrored(&self, out_is: *mut BOOL) -> HRESULT; //
-
-    pub unsafe fn unknown1(&self, arg: *mut INT) -> HRESULT;
-    pub unsafe fn unknown2(&self, arg: *mut INT) -> HRESULT;
-    pub unsafe fn unknown3(&self, arg: *mut INT) -> HRESULT;
-    pub unsafe fn unknown4(&self, arg: INT) -> HRESULT;
-    pub unsafe fn unknown5(&self, arg: *mut INT) -> HRESULT;
-    pub unsafe fn unknown6(&self, arg: INT) -> HRESULT;
-    pub unsafe fn unknown7(&self) -> HRESULT;
-    pub unsafe fn unknown8(&self, arg: *mut INT) -> HRESULT;
-    pub unsafe fn unknown9(&self, arg: INT) -> HRESULT;
-    pub unsafe fn unknown10(&self, arg: INT, arg2: INT) -> HRESULT;
-    pub unsafe fn unknown11(&self, arg: INT) -> HRESULT;
-    pub unsafe fn unknown12(&self, arg: *mut SIZE) -> HRESULT;
-}
-
-#[windows_interface::interface("3F07F4BE-B107-441A-AF0F-39D82529072C")]
-pub unsafe trait IVirtualDesktop: IUnknown {
-    pub unsafe fn is_view_visible(
-        &self,
-        p_view: ComIn<IApplicationView>,
-        out_bool: *mut u32,
-    ) -> HRESULT;
-    pub unsafe fn get_id(&self, out_guid: *mut GUID) -> HRESULT;
-    pub unsafe fn get_name(&self, out_string: *mut HSTRING) -> HRESULT;
-    pub unsafe fn get_wallpaper(&self, out_string: *mut HSTRING) -> HRESULT;
-}
-
-#[windows_interface::interface("1841c6d7-4f9d-42c0-af41-8747538f10e5")]
-pub unsafe trait IApplicationViewCollection: IUnknown {
-    pub unsafe fn get_views(&self, out_views: *mut IObjectArray) -> HRESULT;
-
-    pub unsafe fn get_views_by_zorder(&self, out_views: *mut IObjectArray) -> HRESULT;
-
-    pub unsafe fn get_views_by_app_user_model_id(
-        &self,
-        id: PCWSTR,
-        out_views: *mut IObjectArray,
-    ) -> HRESULT;
-
-    pub unsafe fn get_view_for_hwnd(
-        &self,
-        window: HWND,
-        out_view: *mut Option<IApplicationView>,
-    ) -> HRESULT;
-
-    pub unsafe fn get_view_for_application(
-        &self,
-        app: IImmersiveApplication,
-        out_view: *mut IApplicationView,
-    ) -> HRESULT;
-
-    pub unsafe fn get_view_for_app_user_model_id(
-        &self,
-        id: PCWSTR,
-        out_view: *mut IApplicationView,
-    ) -> HRESULT;
-
-    pub unsafe fn get_view_in_focus(&self, out_view: *mut IApplicationView) -> HRESULT;
-
-    pub unsafe fn try_get_last_active_visible_view(
-        &self,
-        out_view: *mut IApplicationView,
-    ) -> HRESULT;
-
-    pub unsafe fn refresh_collection(&self) -> HRESULT;
-
-    pub unsafe fn register_for_application_view_changes(
-        &self,
-        listener: IApplicationViewChangeListener,
-        out_id: *mut DWORD,
-    ) -> HRESULT;
-
-    pub unsafe fn unregister_for_application_view_changes(&self, id: DWORD) -> HRESULT;
-}
-
-#[windows_interface::interface("B9E5E94D-233E-49AB-AF5C-2B4541C3AADE")]
-pub unsafe trait IVirtualDesktopNotification: IUnknown {
-    pub unsafe fn virtual_desktop_created(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_destroy_begin(
-        &self,
-        desktop_destroyed: ComIn<IVirtualDesktop>,
-        desktop_fallback: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_destroy_failed(
-        &self,
-        desktop_destroyed: ComIn<IVirtualDesktop>,
-        desktop_fallback: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_destroyed(
-        &self,
-        desktop_destroyed: ComIn<IVirtualDesktop>,
-        desktop_fallback: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_moved(
-        &self,
-        desktop: ComIn<IVirtualDesktop>,
-        old_index: i64,
-        new_index: i64,
-    ) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_name_changed(
-        &self,
-        desktop: ComIn<IVirtualDesktop>,
-        name: HSTRING,
-    ) -> HRESULT;
-
-    pub unsafe fn view_virtual_desktop_changed(&self, view: ComIn<IApplicationView>) -> HRESULT;
-
-    pub unsafe fn current_virtual_desktop_changed(
-        &self,
-        desktop_old: ComIn<IVirtualDesktop>,
-        desktop_new: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_wallpaper_changed(
-        &self,
-        desktop: ComIn<IVirtualDesktop>,
-        name: HSTRING,
-    ) -> HRESULT;
-
-    pub unsafe fn virtual_desktop_switched(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
-
-    pub unsafe fn remote_virtual_desktop_connected(
-        &self,
-        desktop: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-}
-
-#[windows_interface::interface("0CD45E71-D927-4F15-8B0A-8FEF525337BF")]
-pub unsafe trait IVirtualDesktopNotificationService: IUnknown {
-    pub unsafe fn register(
-        &self,
-        notification: *mut std::ffi::c_void, // *const IVirtualDesktopNotification,
-        out_cookie: *mut DWORD,
-    ) -> HRESULT;
-
-    pub unsafe fn unregister(&self, cookie: u32) -> HRESULT;
-}
-
-#[windows_interface::interface("53F5CA0B-158F-4124-900C-057158060B27")]
-pub unsafe trait IVirtualDesktopManagerInternal: IUnknown {
-    pub unsafe fn get_desktop_count(&self, out_count: *mut UINT) -> HRESULT;
-
-    pub unsafe fn move_view_to_desktop(
-        &self,
-        view: ComIn<IApplicationView>,
-        desktop: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn can_move_view_between_desktops(
-        &self,
-        view: ComIn<IApplicationView>,
-        can_move: *mut i32,
-    ) -> HRESULT;
-
-    pub unsafe fn get_current_desktop(&self, out_desktop: *mut Option<IVirtualDesktop>) -> HRESULT;
-
-    pub unsafe fn get_desktops(&self, out_desktops: *mut Option<IObjectArray>) -> HRESULT;
-
-    /// Get next or previous desktop
-    ///
-    /// Direction values:
-    /// 3 = Left direction
-    /// 4 = Right direction
-    pub unsafe fn get_adjacent_desktop(
-        &self,
-        in_desktop: ComIn<IVirtualDesktop>,
-        direction: UINT,
-        out_pp_desktop: *mut Option<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn switch_desktop(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
-
-    pub unsafe fn create_desktop(&self, out_desktop: *mut Option<IVirtualDesktop>) -> HRESULT;
-
-    pub unsafe fn move_desktop(&self, in_desktop: ComIn<IVirtualDesktop>, index: UINT) -> HRESULT;
-
-    pub unsafe fn remove_desktop(
-        &self,
-        destroy_desktop: ComIn<IVirtualDesktop>,
-        fallback_desktop: ComIn<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn find_desktop(
-        &self,
-        guid: *const GUID,
-        out_desktop: *mut Option<IVirtualDesktop>,
-    ) -> HRESULT;
-
-    pub unsafe fn get_desktop_switch_include_exclude_views(
-        &self,
-        desktop: ComIn<IVirtualDesktop>,
-        out_pp_desktops1: *mut IObjectArray,
-        out_pp_desktops2: *mut IObjectArray,
-    ) -> HRESULT;
-
-    pub unsafe fn set_name(&self, desktop: ComIn<IVirtualDesktop>, name: HSTRING) -> HRESULT;
-    pub unsafe fn set_wallpaper(&self, desktop: ComIn<IVirtualDesktop>, name: HSTRING) -> HRESULT;
-    pub unsafe fn update_wallpaper_for_all(&self, name: HSTRING) -> HRESULT;
-}
-
-#[windows_interface::interface("4CE81583-1E4C-4632-A621-07A53543148F")]
-pub unsafe trait IVirtualDesktopPinnedApps: IUnknown {
-    pub unsafe fn is_app_pinned(&self, app_id: PCWSTR, out_iss: *mut bool) -> HRESULT;
-    pub unsafe fn pin_app(&self, app_id: PCWSTR) -> HRESULT;
-    pub unsafe fn unpin_app(&self, app_id: PCWSTR) -> HRESULT;
-
-    pub unsafe fn is_view_pinned(
-        &self,
-        view: ComIn<IApplicationView>,
-        out_iss: *mut bool,
-    ) -> HRESULT;
-    pub unsafe fn pin_view(&self, view: ComIn<IApplicationView>) -> HRESULT;
-    pub unsafe fn unpin_view(&self, view: ComIn<IApplicationView>) -> HRESULT;
 }

--- a/src/interfaces/build_10240.rs
+++ b/src/interfaces/build_10240.rs
@@ -1,0 +1,366 @@
+//! Support for Windows 10.
+//!
+//! These definitions should be valid from Windows version `10240` (inclusive) to `22000` (exclusive).
+//!
+//! # References
+//!
+//! - Interface ids at [VirtualDesktop/src/VirtualDesktop/app.config at a6c69e420307e0717f296501c1e7595977e27b6b · Grabacr07/VirtualDesktop](https://github.com/Grabacr07/VirtualDesktop/blob/a6c69e420307e0717f296501c1e7595977e27b6b/src/VirtualDesktop/app.config)
+//! - Bindings at [VirtualDesktop/src/VirtualDesktop/Interop at a6c69e420307e0717f296501c1e7595977e27b6b · Grabacr07/VirtualDesktop](https://github.com/Grabacr07/VirtualDesktop/tree/a6c69e420307e0717f296501c1e7595977e27b6b/src/VirtualDesktop/Interop)
+//!   - These are actually compiled when the app is executed by the `ComInterfaceAssemblyBuilder.CreateAssembly` method at: [VirtualDesktop/src/VirtualDesktop/Interop/ComInterfaceAssemblyBuilder.cs at a6c69e420307e0717f296501c1e7595977e27b6b · Grabacr07/VirtualDesktop](https://github.com/Grabacr07/VirtualDesktop/blob/a6c69e420307e0717f296501c1e7595977e27b6b/src/VirtualDesktop/Interop/ComInterfaceAssemblyBuilder.cs#L73-L192)
+//! - Bindings at [MScholtes/VirtualDesktop at 6de804dced760778450ae3cd1481f8969f75fb39](https://github.com/MScholtes/VirtualDesktop/tree/6de804dced760778450ae3cd1481f8969f75fb39)
+use super::*;
+
+#[windows_interface::interface("871F602A-2B58-42B4-8C4B-6C43D642C06F")]
+pub unsafe trait IApplicationView: IUnknown {
+    /* IInspecateble */
+    pub unsafe fn get_iids(
+        &self,
+        out_iid_count: *mut ULONG,
+        out_opt_iid_array_ptr: *mut *mut GUID,
+    ) -> HRESULT;
+    pub unsafe fn get_runtime_class_name(&self, out_opt_class_name: *mut HSTRING) -> HRESULT;
+    pub unsafe fn get_trust_level(&self, ptr_trust_level: LPVOID) -> HRESULT;
+
+    /* IApplicationView methods */
+    pub unsafe fn set_focus(&self) -> HRESULT;
+    pub unsafe fn switch_to(&self) -> HRESULT;
+
+    pub unsafe fn try_invoke_back(&self, ptr_async_callback: IAsyncCallback) -> HRESULT;
+    pub unsafe fn get_thumbnail_window(&self, out_hwnd: *mut HWND) -> HRESULT;
+    pub unsafe fn get_monitor(&self, out_monitors: *mut *mut IImmersiveMonitor) -> HRESULT;
+    pub unsafe fn get_visibility(&self, out_int: LPVOID) -> HRESULT;
+    pub unsafe fn set_cloak(
+        &self,
+        application_view_cloak_type: APPLICATION_VIEW_CLOAK_TYPE,
+        unknown: INT,
+    ) -> HRESULT;
+    pub unsafe fn get_position(
+        &self,
+        unknowniid: *const GUID,
+        unknown_array_ptr: LPVOID,
+    ) -> HRESULT;
+    pub unsafe fn set_position(&self, view_position: *mut IApplicationViewPosition) -> HRESULT;
+    pub unsafe fn insert_after_window(&self, window: HWND) -> HRESULT;
+    pub unsafe fn get_extended_frame_position(&self, rect: *mut RECT) -> HRESULT;
+    pub unsafe fn get_app_user_model_id(&self, id: *mut PWSTR) -> HRESULT; // Proc17
+    pub unsafe fn set_app_user_model_id(&self, id: PCWSTR) -> HRESULT;
+    pub unsafe fn is_equal_by_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_result: *mut INT,
+    ) -> HRESULT;
+
+    /*** IApplicationView methods ***/
+    pub unsafe fn get_view_state(&self, out_state: *mut UINT) -> HRESULT; // Proc20
+    pub unsafe fn set_view_state(&self, state: UINT) -> HRESULT; // Proc21
+    pub unsafe fn get_neediness(&self, out_neediness: *mut INT) -> HRESULT; // Proc22
+    pub unsafe fn get_last_activation_timestamp(
+        &self,
+        out_timestamp: *mut ULONGLONG,
+    ) -> HRESULT;
+    pub unsafe fn set_last_activation_timestamp(&self, timestamp: ULONGLONG) -> HRESULT;
+    pub unsafe fn get_virtual_desktop_id(&self, out_desktop_guid: *mut GUID) -> HRESULT;
+    pub unsafe fn set_virtual_desktop_id(&self, desktop_guid: *const GUID) -> HRESULT;
+    pub unsafe fn get_show_in_switchers(&self, out_show: *mut INT) -> HRESULT;
+    pub unsafe fn set_show_in_switchers(&self, show: INT) -> HRESULT;
+    pub unsafe fn get_scale_factor(&self, out_scale_factor: *mut INT) -> HRESULT;
+    pub unsafe fn can_receive_input(&self, out_can: *mut BOOL) -> HRESULT;
+    pub unsafe fn get_compatibility_policy_type(
+        &self,
+        out_policy_type: *mut APPLICATION_VIEW_COMPATIBILITY_POLICY,
+    ) -> HRESULT;
+    pub unsafe fn set_compatibility_policy_type(
+        &self,
+        policy_type: APPLICATION_VIEW_COMPATIBILITY_POLICY,
+    ) -> HRESULT;
+
+    pub unsafe fn get_size_constraints(
+        &self,
+        monitor: *mut IImmersiveMonitor,
+        out_size1: *mut SIZE,
+        out_size2: *mut SIZE,
+    ) -> HRESULT;
+    pub unsafe fn get_size_constraints_for_dpi(
+        &self,
+        dpi: UINT,
+        out_size1: *mut SIZE,
+        out_size2: *mut SIZE,
+    ) -> HRESULT;
+    pub unsafe fn set_size_constraints_for_dpi(
+        &self,
+        dpi: *const UINT,
+        size1: *const SIZE,
+        size2: *const SIZE,
+    ) -> HRESULT;
+
+    pub unsafe fn on_min_size_preferences_updated(&self, window: HWND) -> HRESULT;
+    pub unsafe fn apply_operation(&self, operation: *mut IApplicationViewOperation) -> HRESULT;
+    pub unsafe fn is_tray(&self, out_is: *mut BOOL) -> HRESULT;
+    pub unsafe fn is_in_high_zorder_band(&self, out_is: *mut BOOL) -> HRESULT;
+    pub unsafe fn is_splash_screen_presented(&self, out_is: *mut BOOL) -> HRESULT;
+    pub unsafe fn flash(&self) -> HRESULT;
+    pub unsafe fn get_root_switchable_owner(&self, app_view: *mut IApplicationView) -> HRESULT; // proc45
+    pub unsafe fn enumerate_ownership_tree(&self, objects: *mut IObjectArray) -> HRESULT; // proc46
+
+    pub unsafe fn get_enterprise_id(&self, out_id: *mut PWSTR) -> HRESULT; // proc47
+    pub unsafe fn is_mirrored(&self, out_is: *mut BOOL) -> HRESULT; //
+
+    pub unsafe fn unknown1(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown2(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown3(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown4(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown5(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown6(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown7(&self) -> HRESULT;
+    pub unsafe fn unknown8(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown9(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown10(&self, arg: INT, arg2: INT) -> HRESULT;
+    pub unsafe fn unknown11(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown12(&self, arg: *mut SIZE) -> HRESULT;
+}
+
+#[windows_interface::interface("FF72FFDD-BE7E-43FC-9C03-AD81681E88E4")]
+pub unsafe trait IVirtualDesktop: IUnknown {
+    pub unsafe fn is_view_visible(
+        &self,
+        p_view: ComIn<IApplicationView>,
+        out_bool: *mut u32,
+    ) -> HRESULT;
+    pub unsafe fn get_id(&self, out_guid: *mut GUID) -> HRESULT;
+}
+
+#[windows_interface::interface("1841C6D7-4F9D-42C0-AF41-8747538F10E5")]
+pub unsafe trait IApplicationViewCollection: IUnknown {
+    pub unsafe fn get_views(&self, out_views: *mut IObjectArray) -> HRESULT;
+
+    pub unsafe fn get_views_by_zorder(&self, out_views: *mut IObjectArray) -> HRESULT;
+
+    pub unsafe fn get_views_by_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_views: *mut IObjectArray,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_hwnd(
+        &self,
+        window: HWND,
+        out_view: *mut Option<IApplicationView>,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_application(
+        &self,
+        app: IImmersiveApplication,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_in_focus(&self, out_view: *mut IApplicationView) -> HRESULT;
+
+    pub unsafe fn refresh_collection(&self) -> HRESULT;
+
+    pub unsafe fn register_for_application_view_changes(
+        &self,
+        listener: IApplicationViewChangeListener,
+        out_id: *mut DWORD,
+    ) -> HRESULT;
+
+    pub unsafe fn unregister_for_application_view_changes(&self, id: DWORD) -> HRESULT;
+}
+
+#[windows_interface::interface("C179334C-4295-40D3-BEA1-C654D965605A")]
+pub unsafe trait IVirtualDesktopNotification: IUnknown {
+    pub unsafe fn virtual_desktop_created(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_destroy_begin(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_destroy_failed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_destroyed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn view_virtual_desktop_changed(&self, view: ComIn<IApplicationView>)
+        -> HRESULT;
+
+    pub unsafe fn current_virtual_desktop_changed(
+        &self,
+        desktop_old: ComIn<IVirtualDesktop>,
+        desktop_new: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+}
+
+#[windows_interface::interface("0CD45E71-D927-4F15-8B0A-8FEF525337BF")]
+pub unsafe trait IVirtualDesktopNotificationService: IUnknown {
+    pub unsafe fn register(
+        &self,
+        notification: *mut std::ffi::c_void, // *const IVirtualDesktopNotification,
+        out_cookie: *mut DWORD,
+    ) -> HRESULT;
+
+    pub unsafe fn unregister(&self, cookie: u32) -> HRESULT;
+}
+
+#[windows_interface::interface("0F3A72B0-4566-487E-9A33-4ED302F6D6CE")]
+pub unsafe trait IVirtualDesktopManagerInternal: IUnknown {
+    pub unsafe fn get_desktop_count(&self, out_count: *mut UINT) -> HRESULT;
+
+    pub unsafe fn move_view_to_desktop(
+        &self,
+        view: ComIn<IApplicationView>,
+        desktop: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn can_move_view_between_desktops(
+        &self,
+        view: ComIn<IApplicationView>,
+        can_move: *mut i32,
+    ) -> HRESULT;
+
+    pub unsafe fn get_current_desktop(
+        &self,
+        out_desktop: *mut Option<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn get_desktops(&self, out_desktops: *mut Option<IObjectArray>) -> HRESULT;
+
+    /// Get next or previous desktop
+    ///
+    /// Direction values:
+    /// 3 = Left direction
+    /// 4 = Right direction
+    pub unsafe fn get_adjacent_desktop(
+        &self,
+        in_desktop: ComIn<IVirtualDesktop>,
+        direction: UINT,
+        out_pp_desktop: *mut Option<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn switch_desktop(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn create_desktop(&self, out_desktop: *mut Option<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn move_desktop(
+        &self,
+        in_desktop: ComIn<IVirtualDesktop>,
+        index: UINT,
+    ) -> HRESULT;
+
+    pub unsafe fn remove_desktop(
+        &self,
+        destroy_desktop: ComIn<IVirtualDesktop>,
+        fallback_desktop: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn find_desktop(
+        &self,
+        guid: *const GUID,
+        out_desktop: *mut Option<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn get_desktop_switch_include_exclude_views(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        out_pp_desktops1: *mut IObjectArray,
+        out_pp_desktops2: *mut IObjectArray,
+    ) -> HRESULT;
+
+    pub unsafe fn set_name(&self, desktop: ComIn<IVirtualDesktop>, name: HSTRING) -> HRESULT;
+    pub unsafe fn set_wallpaper(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        name: HSTRING,
+    ) -> HRESULT;
+    pub unsafe fn update_wallpaper_for_all(&self, name: HSTRING) -> HRESULT;
+}
+
+#[windows_interface::interface("4CE81583-1E4C-4632-A621-07A53543148F")]
+pub unsafe trait IVirtualDesktopPinnedApps: IUnknown {
+    pub unsafe fn is_app_pinned(&self, app_id: PCWSTR, out_iss: *mut bool) -> HRESULT;
+    pub unsafe fn pin_app(&self, app_id: PCWSTR) -> HRESULT;
+    pub unsafe fn unpin_app(&self, app_id: PCWSTR) -> HRESULT;
+
+    pub unsafe fn is_view_pinned(
+        &self,
+        view: ComIn<IApplicationView>,
+        out_iss: *mut bool,
+    ) -> HRESULT;
+    pub unsafe fn pin_view(&self, view: ComIn<IApplicationView>) -> HRESULT;
+    pub unsafe fn unpin_view(&self, view: ComIn<IApplicationView>) -> HRESULT;
+}
+
+/// Implements an unstable interface that is only valid for a single Windows
+/// version using a more stable trait that works for all Windows versions.
+#[windows::core::implement(IVirtualDesktopNotification)]
+pub struct VirtualDesktopNotificationAdaptor<T>
+where
+    T: build_dyn::IVirtualDesktopNotification_Impl,
+{
+    pub inner: T,
+}
+impl<T> IVirtualDesktopNotification_Impl for VirtualDesktopNotificationAdaptor<T>
+where
+    T: build_dyn::IVirtualDesktopNotification_Impl,
+{
+    unsafe fn current_virtual_desktop_changed(
+        &self,
+        desktop_old: ComIn<IVirtualDesktop>,
+        desktop_new: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner
+            .current_virtual_desktop_changed((&*desktop_old).into(), (&*desktop_new).into())
+    }
+
+    unsafe fn virtual_desktop_created(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT {
+        self.inner.virtual_desktop_created((&*desktop).into())
+    }
+
+    unsafe fn virtual_desktop_destroy_begin(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner.virtual_desktop_destroy_begin(
+            (&*desktop_destroyed).into(),
+            (&*desktop_fallback).into(),
+        )
+    }
+
+    unsafe fn virtual_desktop_destroy_failed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner.virtual_desktop_destroy_failed(
+            (&*desktop_destroyed).into(),
+            (&*desktop_fallback).into(),
+        )
+    }
+
+    unsafe fn virtual_desktop_destroyed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner
+            .virtual_desktop_destroyed((&*desktop_destroyed).into(), (&*desktop_fallback).into())
+    }
+
+    unsafe fn view_virtual_desktop_changed(&self, view: ComIn<IApplicationView>) -> HRESULT {
+        self.inner.view_virtual_desktop_changed((&*view).into())
+    }
+}

--- a/src/interfaces/build_22000.rs
+++ b/src/interfaces/build_22000.rs
@@ -1,0 +1,409 @@
+//! Support for Windows 11.
+use super::*;
+
+#[windows_interface::interface("372E1D3B-38D3-42E4-A15B-8AB2B178F513")]
+pub unsafe trait IApplicationView: IUnknown {
+    /* IInspecateble */
+    pub unsafe fn get_iids(
+        &self,
+        out_iid_count: *mut ULONG,
+        out_opt_iid_array_ptr: *mut *mut GUID,
+    ) -> HRESULT;
+    pub unsafe fn get_runtime_class_name(&self, out_opt_class_name: *mut HSTRING) -> HRESULT;
+    pub unsafe fn get_trust_level(&self, ptr_trust_level: LPVOID) -> HRESULT;
+
+    /* IApplicationView methods */
+    pub unsafe fn set_focus(&self) -> HRESULT;
+    pub unsafe fn switch_to(&self) -> HRESULT;
+
+    pub unsafe fn try_invoke_back(&self, ptr_async_callback: IAsyncCallback) -> HRESULT;
+    pub unsafe fn get_thumbnail_window(&self, out_hwnd: *mut HWND) -> HRESULT;
+    pub unsafe fn get_monitor(&self, out_monitors: *mut *mut IImmersiveMonitor) -> HRESULT;
+    pub unsafe fn get_visibility(&self, out_int: LPVOID) -> HRESULT;
+    pub unsafe fn set_cloak(
+        &self,
+        application_view_cloak_type: APPLICATION_VIEW_CLOAK_TYPE,
+        unknown: INT,
+    ) -> HRESULT;
+    pub unsafe fn get_position(
+        &self,
+        unknowniid: *const GUID,
+        unknown_array_ptr: LPVOID,
+    ) -> HRESULT;
+    pub unsafe fn set_position(&self, view_position: *mut IApplicationViewPosition) -> HRESULT;
+    pub unsafe fn insert_after_window(&self, window: HWND) -> HRESULT;
+    pub unsafe fn get_extended_frame_position(&self, rect: *mut RECT) -> HRESULT;
+    pub unsafe fn get_app_user_model_id(&self, id: *mut PWSTR) -> HRESULT; // Proc17
+    pub unsafe fn set_app_user_model_id(&self, id: PCWSTR) -> HRESULT;
+    pub unsafe fn is_equal_by_app_user_model_id(&self, id: PCWSTR, out_result: *mut INT)
+        -> HRESULT;
+
+    /*** IApplicationView methods ***/
+    pub unsafe fn get_view_state(&self, out_state: *mut UINT) -> HRESULT; // Proc20
+    pub unsafe fn set_view_state(&self, state: UINT) -> HRESULT; // Proc21
+    pub unsafe fn get_neediness(&self, out_neediness: *mut INT) -> HRESULT; // Proc22
+    pub unsafe fn get_last_activation_timestamp(&self, out_timestamp: *mut ULONGLONG) -> HRESULT;
+    pub unsafe fn set_last_activation_timestamp(&self, timestamp: ULONGLONG) -> HRESULT;
+    pub unsafe fn get_virtual_desktop_id(&self, out_desktop_guid: *mut GUID) -> HRESULT;
+    pub unsafe fn set_virtual_desktop_id(&self, desktop_guid: *const GUID) -> HRESULT;
+    pub unsafe fn get_show_in_switchers(&self, out_show: *mut INT) -> HRESULT;
+    pub unsafe fn set_show_in_switchers(&self, show: INT) -> HRESULT;
+    pub unsafe fn get_scale_factor(&self, out_scale_factor: *mut INT) -> HRESULT;
+    pub unsafe fn can_receive_input(&self, out_can: *mut BOOL) -> HRESULT;
+    pub unsafe fn get_compatibility_policy_type(
+        &self,
+        out_policy_type: *mut APPLICATION_VIEW_COMPATIBILITY_POLICY,
+    ) -> HRESULT;
+    pub unsafe fn set_compatibility_policy_type(
+        &self,
+        policy_type: APPLICATION_VIEW_COMPATIBILITY_POLICY,
+    ) -> HRESULT;
+
+    pub unsafe fn get_size_constraints(
+        &self,
+        monitor: *mut IImmersiveMonitor,
+        out_size1: *mut SIZE,
+        out_size2: *mut SIZE,
+    ) -> HRESULT;
+    pub unsafe fn get_size_constraints_for_dpi(
+        &self,
+        dpi: UINT,
+        out_size1: *mut SIZE,
+        out_size2: *mut SIZE,
+    ) -> HRESULT;
+    pub unsafe fn set_size_constraints_for_dpi(
+        &self,
+        dpi: *const UINT,
+        size1: *const SIZE,
+        size2: *const SIZE,
+    ) -> HRESULT;
+
+    pub unsafe fn on_min_size_preferences_updated(&self, window: HWND) -> HRESULT;
+    pub unsafe fn apply_operation(&self, operation: *mut IApplicationViewOperation) -> HRESULT;
+    pub unsafe fn is_tray(&self, out_is: *mut BOOL) -> HRESULT;
+    pub unsafe fn is_in_high_zorder_band(&self, out_is: *mut BOOL) -> HRESULT;
+    pub unsafe fn is_splash_screen_presented(&self, out_is: *mut BOOL) -> HRESULT;
+    pub unsafe fn flash(&self) -> HRESULT;
+    pub unsafe fn get_root_switchable_owner(&self, app_view: *mut IApplicationView) -> HRESULT; // proc45
+    pub unsafe fn enumerate_ownership_tree(&self, objects: *mut IObjectArray) -> HRESULT; // proc46
+
+    pub unsafe fn get_enterprise_id(&self, out_id: *mut PWSTR) -> HRESULT; // proc47
+    pub unsafe fn is_mirrored(&self, out_is: *mut BOOL) -> HRESULT; //
+
+    pub unsafe fn unknown1(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown2(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown3(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown4(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown5(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown6(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown7(&self) -> HRESULT;
+    pub unsafe fn unknown8(&self, arg: *mut INT) -> HRESULT;
+    pub unsafe fn unknown9(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown10(&self, arg: INT, arg2: INT) -> HRESULT;
+    pub unsafe fn unknown11(&self, arg: INT) -> HRESULT;
+    pub unsafe fn unknown12(&self, arg: *mut SIZE) -> HRESULT;
+}
+
+#[windows_interface::interface("3F07F4BE-B107-441A-AF0F-39D82529072C")]
+pub unsafe trait IVirtualDesktop: IUnknown {
+    pub unsafe fn is_view_visible(
+        &self,
+        p_view: ComIn<IApplicationView>,
+        out_bool: *mut u32,
+    ) -> HRESULT;
+    pub unsafe fn get_id(&self, out_guid: *mut GUID) -> HRESULT;
+    pub unsafe fn get_name(&self, out_string: *mut HSTRING) -> HRESULT;
+    pub unsafe fn get_wallpaper(&self, out_string: *mut HSTRING) -> HRESULT;
+}
+
+#[windows_interface::interface("1841c6d7-4f9d-42c0-af41-8747538f10e5")]
+pub unsafe trait IApplicationViewCollection: IUnknown {
+    pub unsafe fn get_views(&self, out_views: *mut IObjectArray) -> HRESULT;
+
+    pub unsafe fn get_views_by_zorder(&self, out_views: *mut IObjectArray) -> HRESULT;
+
+    pub unsafe fn get_views_by_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_views: *mut IObjectArray,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_hwnd(
+        &self,
+        window: HWND,
+        out_view: *mut Option<IApplicationView>,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_application(
+        &self,
+        app: IImmersiveApplication,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_in_focus(&self, out_view: *mut IApplicationView) -> HRESULT;
+
+    pub unsafe fn try_get_last_active_visible_view(
+        &self,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT;
+
+    pub unsafe fn refresh_collection(&self) -> HRESULT;
+
+    pub unsafe fn register_for_application_view_changes(
+        &self,
+        listener: IApplicationViewChangeListener,
+        out_id: *mut DWORD,
+    ) -> HRESULT;
+
+    pub unsafe fn unregister_for_application_view_changes(&self, id: DWORD) -> HRESULT;
+}
+
+#[windows_interface::interface("B9E5E94D-233E-49AB-AF5C-2B4541C3AADE")]
+pub unsafe trait IVirtualDesktopNotification: IUnknown {
+    pub unsafe fn virtual_desktop_created(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_destroy_begin(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_destroy_failed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_destroyed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_moved(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        old_index: i64,
+        new_index: i64,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_name_changed(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        name: HSTRING,
+    ) -> HRESULT;
+
+    pub unsafe fn view_virtual_desktop_changed(&self, view: ComIn<IApplicationView>) -> HRESULT;
+
+    pub unsafe fn current_virtual_desktop_changed(
+        &self,
+        desktop_old: ComIn<IVirtualDesktop>,
+        desktop_new: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_wallpaper_changed(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        name: HSTRING,
+    ) -> HRESULT;
+
+    pub unsafe fn virtual_desktop_switched(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn remote_virtual_desktop_connected(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+}
+
+#[windows_interface::interface("0CD45E71-D927-4F15-8B0A-8FEF525337BF")]
+pub unsafe trait IVirtualDesktopNotificationService: IUnknown {
+    pub unsafe fn register(
+        &self,
+        notification: *mut std::ffi::c_void, // *const IVirtualDesktopNotification,
+        out_cookie: *mut DWORD,
+    ) -> HRESULT;
+
+    pub unsafe fn unregister(&self, cookie: u32) -> HRESULT;
+}
+
+#[windows_interface::interface("53F5CA0B-158F-4124-900C-057158060B27")]
+pub unsafe trait IVirtualDesktopManagerInternal: IUnknown {
+    pub unsafe fn get_desktop_count(&self, out_count: *mut UINT) -> HRESULT;
+
+    pub unsafe fn move_view_to_desktop(
+        &self,
+        view: ComIn<IApplicationView>,
+        desktop: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn can_move_view_between_desktops(
+        &self,
+        view: ComIn<IApplicationView>,
+        can_move: *mut i32,
+    ) -> HRESULT;
+
+    pub unsafe fn get_current_desktop(&self, out_desktop: *mut Option<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn get_desktops(&self, out_desktops: *mut Option<IObjectArray>) -> HRESULT;
+
+    /// Get next or previous desktop
+    ///
+    /// Direction values:
+    /// 3 = Left direction
+    /// 4 = Right direction
+    pub unsafe fn get_adjacent_desktop(
+        &self,
+        in_desktop: ComIn<IVirtualDesktop>,
+        direction: UINT,
+        out_pp_desktop: *mut Option<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn switch_desktop(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn create_desktop(&self, out_desktop: *mut Option<IVirtualDesktop>) -> HRESULT;
+
+    pub unsafe fn move_desktop(&self, in_desktop: ComIn<IVirtualDesktop>, index: UINT) -> HRESULT;
+
+    pub unsafe fn remove_desktop(
+        &self,
+        destroy_desktop: ComIn<IVirtualDesktop>,
+        fallback_desktop: ComIn<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn find_desktop(
+        &self,
+        guid: *const GUID,
+        out_desktop: *mut Option<IVirtualDesktop>,
+    ) -> HRESULT;
+
+    pub unsafe fn get_desktop_switch_include_exclude_views(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        out_pp_desktops1: *mut IObjectArray,
+        out_pp_desktops2: *mut IObjectArray,
+    ) -> HRESULT;
+
+    pub unsafe fn set_name(&self, desktop: ComIn<IVirtualDesktop>, name: HSTRING) -> HRESULT;
+    pub unsafe fn set_wallpaper(&self, desktop: ComIn<IVirtualDesktop>, name: HSTRING) -> HRESULT;
+    pub unsafe fn update_wallpaper_for_all(&self, name: HSTRING) -> HRESULT;
+}
+
+#[windows_interface::interface("4CE81583-1E4C-4632-A621-07A53543148F")]
+pub unsafe trait IVirtualDesktopPinnedApps: IUnknown {
+    pub unsafe fn is_app_pinned(&self, app_id: PCWSTR, out_iss: *mut bool) -> HRESULT;
+    pub unsafe fn pin_app(&self, app_id: PCWSTR) -> HRESULT;
+    pub unsafe fn unpin_app(&self, app_id: PCWSTR) -> HRESULT;
+
+    pub unsafe fn is_view_pinned(
+        &self,
+        view: ComIn<IApplicationView>,
+        out_iss: *mut bool,
+    ) -> HRESULT;
+    pub unsafe fn pin_view(&self, view: ComIn<IApplicationView>) -> HRESULT;
+    pub unsafe fn unpin_view(&self, view: ComIn<IApplicationView>) -> HRESULT;
+}
+
+/// Implements an unstable interface that is only valid for a single Windows
+/// version using a more stable trait that works for all Windows versions.
+#[windows::core::implement(IVirtualDesktopNotification)]
+pub struct VirtualDesktopNotificationAdaptor<T>
+where
+    T: build_dyn::IVirtualDesktopNotification_Impl,
+{
+    pub inner: T,
+}
+impl<T> IVirtualDesktopNotification_Impl for VirtualDesktopNotificationAdaptor<T>
+where
+    T: build_dyn::IVirtualDesktopNotification_Impl,
+{
+    unsafe fn current_virtual_desktop_changed(
+        &self,
+        desktop_old: ComIn<IVirtualDesktop>,
+        desktop_new: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner
+            .current_virtual_desktop_changed((&*desktop_old).into(), (&*desktop_new).into())
+    }
+
+    unsafe fn virtual_desktop_wallpaper_changed(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        name: HSTRING,
+    ) -> HRESULT {
+        self.inner
+            .virtual_desktop_wallpaper_changed((&*desktop).into(), name)
+    }
+
+    unsafe fn virtual_desktop_created(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT {
+        self.inner.virtual_desktop_created((&*desktop).into())
+    }
+
+    unsafe fn virtual_desktop_destroy_begin(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner.virtual_desktop_destroy_begin(
+            (&*desktop_destroyed).into(),
+            (&*desktop_fallback).into(),
+        )
+    }
+
+    unsafe fn virtual_desktop_destroy_failed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner.virtual_desktop_destroy_failed(
+            (&*desktop_destroyed).into(),
+            (&*desktop_fallback).into(),
+        )
+    }
+
+    unsafe fn virtual_desktop_destroyed(
+        &self,
+        desktop_destroyed: ComIn<IVirtualDesktop>,
+        desktop_fallback: ComIn<IVirtualDesktop>,
+    ) -> HRESULT {
+        self.inner
+            .virtual_desktop_destroyed((&*desktop_destroyed).into(), (&*desktop_fallback).into())
+    }
+
+    unsafe fn virtual_desktop_moved(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        old_index: i64,
+        new_index: i64,
+    ) -> HRESULT {
+        self.inner
+            .virtual_desktop_moved((&*desktop).into(), old_index, new_index)
+    }
+
+    unsafe fn virtual_desktop_name_changed(
+        &self,
+        desktop: ComIn<IVirtualDesktop>,
+        name: HSTRING,
+    ) -> HRESULT {
+        self.inner
+            .virtual_desktop_name_changed((&*desktop).into(), name)
+    }
+
+    unsafe fn view_virtual_desktop_changed(&self, view: ComIn<IApplicationView>) -> HRESULT {
+        self.inner.view_virtual_desktop_changed((&*view).into())
+    }
+
+    unsafe fn virtual_desktop_switched(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT {
+        self.inner.virtual_desktop_switched((&*desktop).into())
+    }
+
+    unsafe fn remote_virtual_desktop_connected(&self, desktop: ComIn<IVirtualDesktop>) -> HRESULT {
+        self.inner
+            .remote_virtual_desktop_connected((&*desktop).into())
+    }
+}

--- a/src/interfaces/build_dyn.rs
+++ b/src/interfaces/build_dyn.rs
@@ -1,0 +1,940 @@
+//! Interface abstraction that allow interacting with COM interfaces even when
+//! we don't know their IID and what exact methods they have until runtime.
+
+use super::*;
+
+use core::{ffi::c_void, marker::PhantomData};
+use windows::{
+    core::{ComInterface, Interface, GUID, HRESULT, HSTRING},
+    Win32::{
+        Foundation::{E_NOTIMPL, HWND},
+        UI::Shell::Common::IObjectArray,
+    },
+};
+
+/// Indicates different Windows versions that have different Virtual Desktop
+/// interfaces.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Default)]
+pub enum WindowsVersion {
+    Build10240,
+    #[default]
+    Build22000,
+}
+impl WindowsVersion {
+    // Aliases used by macros (should match the module names above):
+    const build_10240: Self = Self::Build10240;
+    const build_22000: Self = Self::Build22000;
+
+    /// Get info about the current Windows version. Only differentiates between
+    /// Windows versions that have different virtual desktop interfaces.
+    ///
+    /// # Determining Windows Version
+    ///
+    /// We could use the [`GetVersionExW` function
+    /// (sysinfoapi.h)](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexw),
+    /// but it is deprecated after Windows 8.1. It also changes behavior depending
+    /// on what manifest is embedded in the executable.
+    ///
+    /// That pages links to [Version Helper functions - Win32
+    /// apps](https://learn.microsoft.com/en-us/windows/win32/sysinfo/version-helper-apis)
+    /// where we are linked to the [`IsWindowsVersionOrGreater` function
+    /// (versionhelpers.h)](https://learn.microsoft.com/en-us/windows/win32/api/VersionHelpers/nf-versionhelpers-iswindowsversionorgreater)
+    /// and the [`VerifyVersionInfoA` function
+    /// (winbase.h)](https://learn.microsoft.com/en-us/windows/win32/api/Winbase/nf-winbase-verifyversioninfoa)
+    /// that it uses internally (though the later function is deprecated in Windows
+    /// 10).
+    ///
+    /// We can use `RtlGetVersion` [RtlGetVersion function (wdm.h) - Windows
+    /// drivers](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion?redirectedfrom=MSDN)
+    /// as mentioned at [c++ - Detecting Windows 10 version - Stack
+    /// Overflow](https://stackoverflow.com/questions/36543301/detecting-windows-10-version/36545162#36545162).
+    ///
+    /// # `windows` API References
+    ///
+    /// - [GetVersionExW in windows::Win32::System::SystemInformation -
+    ///   Rust](https://microsoft.github.io/windows-docs-rs/doc/windows/Win32/System/SystemInformation/fn.GetVersionExW.html)
+    ///   - Affected by manifest.
+    /// - [RtlGetVersion in windows::Wdk::System::SystemServices -
+    ///   Rust](https://microsoft.github.io/windows-docs-rs/doc/windows/Wdk/System/SystemServices/fn.RtlGetVersion.html)
+    ///   - Always returns the correct version.
+    pub fn get() -> Self {
+        static INIT: std::sync::OnceLock<WindowsVersion> = std::sync::OnceLock::new();
+        *INIT.get_or_init(|| {
+            let mut version: windows::Win32::System::SystemInformation::OSVERSIONINFOW =
+                Default::default();
+            version.dwOSVersionInfoSize = core::mem::size_of_val(&version) as u32;
+            let res = unsafe { windows::Wdk::System::SystemServices::RtlGetVersion(&mut version) };
+            if res.is_err() {
+                return Default::default();
+            }
+            if version.dwBuildNumber < 22000 {
+                WindowsVersion::Build10240
+            } else {
+                WindowsVersion::Build22000
+            }
+        })
+    }
+}
+
+/// Do an action with the type of the actual COM Interface on this Windows
+/// version.
+///
+/// This is implemented for the more generic COM interfaces that don't know
+/// their IID at compile time. Those implementations will put a bound on `F` so
+/// that it must accept all concrete COM types that might be used.
+pub trait WithVersionedType<F, R> {
+    /// Invokes the callback with the COM interface type of this Windows
+    /// version. Return `None` if the interface doesn't exist on this platform.
+    fn with_versioned_type(callback: F) -> Option<R>;
+}
+/// A callback that will be invoked with the actual COM interface type for a
+/// specific Windows version.
+///
+/// Implement this when you want to make use of a concrete COM interface type.
+pub trait WithVersionedTypeCallback<T: ComInterface, R> {
+    fn call(self) -> R;
+}
+
+/// Generates support code for a COM interface.
+///
+/// Syntax is: `as CreatedEnumName for InterfaceName in $(all)? [version_module_1, version_module_2 $(,)?]`
+macro_rules! support_interface {
+    (@inner {$dollar:tt} as $state:ident for $name:ident in $(all $(@ $all:tt)?)? [$($version:ident),* $(,)?]) => {
+        $(
+            // assert_eq_size from static_assertions crate
+            const _: fn() = || {
+                // We need this since we transmute and pointer cast between the two types.
+                let _ = core::mem::transmute::<$name, self::$version::$name>;
+            };
+        )*
+
+        // Maybe enforce that all build versions are supported by this interface:
+        #[allow(unreachable_patterns)]
+        const _: fn(WindowsVersion) = |version: WindowsVersion| {
+            match version {
+                $(WindowsVersion::$version => (),)*
+                // If there is no "all" word in the macro input then:
+                //   all() => true
+                // Otherwise:
+                //   all(false) => false
+                //   any() => false
+                //   all(any()) => false
+                // And the default macro arm will be hidden.
+                #[cfg(all($(any() $($all)?)?))]
+                _ => (),
+            }
+        };
+
+        /// An enum with one variant per Windows version that is supported by
+        /// this interface. Use the `from_typed` function to construct this
+        /// type.
+        #[allow(non_camel_case_types)]
+        enum $state<'a> {
+            $( $version(ComIn<'a, self::$version::$name>) ),*
+        }
+        impl<'a> $state<'a> {
+            fn from_typed(data: &'a $name) -> Self {
+                unsafe { Self::from_raw(&data.0) }
+            }
+            /// # Safety
+            ///
+            /// The COM object must implement the expected interface.
+            #[allow(unreachable_patterns)]
+            unsafe fn from_raw(data: &'a IUnknown) -> Self {
+                let win_ver = WindowsVersion::get();
+                match win_ver {
+                    $(WindowsVersion::$version => $state::$version(core::mem::transmute_copy::<IUnknown, ComIn<'_, _>>(data)),)*
+                    _ => unreachable!("Tried to cast into a COM interface that wasn't available for the current Windows version"),
+                }
+            }
+        }
+        impl $name {
+            /// Convert from a raw pointer to the COM interface.
+            ///
+            /// # Safety
+            ///
+            /// The pointer must be an instance of the COM interface indicated
+            /// by the `IID` method.
+            pub unsafe fn from_raw(ptr: *mut c_void) -> Self {
+                Self(IUnknown::from_raw(ptr))
+            }
+            /// The IID for the COM interface that is supported by this
+            /// platform, return a zeroed GUID if the interface isn't supported.
+            #[allow(non_snake_case, unreachable_patterns)]
+            pub fn IID() -> GUID {
+                match WindowsVersion::get() {
+                    $(WindowsVersion::$version => self::$version::$name::IID,)*
+                    _ => GUID::zeroed(),
+                }
+            }
+        }
+        /// Allow direct access to the wrapped COM interface type if required.
+        impl<F, R> WithVersionedType<F, R> for $name
+        where
+            $(
+                F: WithVersionedTypeCallback<self::$version::$name, R>,
+            )*
+        {
+            #[allow(unreachable_patterns)]
+            fn with_versioned_type(callback: F) -> Option<R> {
+                match WindowsVersion::get() {
+                    $(WindowsVersion::$version => Some(<F as WithVersionedTypeCallback<self::$version::$name, R>>::call(callback)),)*
+                    _ => None,
+                }
+            }
+        }
+        $(
+            /// Version specific -> Generic interface
+            impl From<self::$version::$name> for $name {
+                fn from(v: self::$version::$name) -> Self {
+                    debug_assert_eq!(
+                        WindowsVersion::get(),
+                        WindowsVersion::$version,
+                        "if we have an COM interface for a specific Windows version then we must already have ensured that it is actually the Windows version the user has"
+                    );
+                    Self(v.into())
+                }
+            }
+            /// Reference to version specific -> Reference to generic interface
+            impl<'a> From<&'a self::$version::$name> for &'a $name {
+                fn from(v: &'a self::$version::$name) -> Self {
+                    debug_assert_eq!(
+                        WindowsVersion::get(),
+                        WindowsVersion::$version,
+                        "if we have an COM interface for a specific Windows version then we must already have ensured that it is actually the Windows version the user has"
+                    );
+                    // Safety: both types are just transparent wrappers over a
+                    // raw pointer and we don't drop either of them.
+                    unsafe {
+                        &*(v as *const self::$version::$name as *const $name)
+                    }
+                }
+            }
+            /// Fallible conversion from generic interface to version specific
+            /// interface.
+            impl From<$name> for self::$version::$name {
+                fn from(v: $name) -> Self {
+                    assert_eq!(WindowsVersion::get(), WindowsVersion::$version);
+                    // Safety: interpret the wrapped raw pointer as the specific COM interface.
+                    unsafe { core::mem::transmute(v.0) }
+                }
+            }
+            impl<'a> From<&'a $name> for ComIn<'a, self::$version::$name> {
+                #[allow(irrefutable_let_patterns)]
+                fn from(v: &'a $name) -> Self {
+                    if let $state::$version(v) = $state::from_typed(v) {
+                        v
+                    } else {
+                        unreachable!("requested a COM interface for a different Windows version than the one that was installed");
+                    }
+                }
+            }
+        )*
+        /// Preform the same action for each version of the wrapped COM interface.
+        ///
+        /// Syntax: GeneralType, |versioned: versioned_mod::VersionedType| block_of_code
+        ///
+        /// Note: named the same as the interface to allow for easier usage with macros.
+        #[allow(unused_macros)]
+        macro_rules! $name {
+            (
+                $dollar this:expr,
+                |$dollar arg:ident
+                    $dollar (
+                        :
+                        $dollar module_name:ident
+                        ::
+                        $dollar arg_ty:ident
+                    )?
+                |
+                $dollar ($dollar body:tt)*
+            ) => {
+                match $state::from_typed(&$dollar this) {
+                    $(
+                        $state::$version($dollar arg) => {
+                            $dollar (
+                                #[allow(unused_imports)]
+                                use self::$version as $dollar module_name;
+                                #[allow(unused_imports)]
+                                use self::$version::$name as $dollar arg_ty;
+                            )?
+                            $dollar ($dollar body)*
+                        },
+                    )*
+                }
+            }
+        }
+    };
+    // Pass an escaped dollar sign to the real macro so that we can construct a
+    // new macro later:
+    (as $state:ident for $name:ident in $($in:tt)*) => {
+        support_interface! { @inner {$} as $state for $name in $($in)* }
+    };
+}
+
+/// Implement a method by calling the same method on the Windows version
+/// dependant COM interface.
+macro_rules! forward_call {
+    (
+        #[forward_for = $name:ident]
+        $( #[$attr:meta] )*
+        $pub:vis
+        $(unsafe $(@ $unsafe:tt)?)?
+        fn $fname:ident (
+            &$self_:ident $(,)? $( $arg_name:ident : $ArgTy:ty ),* $(,)?
+        ) -> $RetTy:ty;
+    ) => (
+        $( #[$attr] )*
+        #[allow(unused_parens)]
+        $pub
+        $(unsafe $($unsafe)?)?
+        fn $fname (
+            &$self_, $( $arg_name : $ArgTy ),*
+        ) -> $RetTy
+        {
+            unsafe {
+                $name!(
+                    $self_,
+                    |v| v.$fname( $(
+                        Into::into($arg_name)
+                    ),*)
+                )
+            }
+        }
+    );
+    (
+        $( #[$attr:meta] )*
+        impl $name:ident {
+            $($item:item)*
+        }
+    ) => {
+        $(#[$attr])*
+        impl $name {
+            $(
+                #[apply(forward_call)]
+                #[forward_for = $name]
+                $item
+            )*
+        }
+    };
+}
+
+support_interface!(as IApplicationViewInner for IApplicationView in all [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IApplicationView(IUnknown);
+impl IApplicationView {
+    /* IInspecateble */
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_iids(
+        &self,
+        out_iid_count: *mut ULONG,
+        out_opt_iid_array_ptr: *mut *mut GUID,
+    ) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_runtime_class_name(&self, out_opt_class_name: *mut HSTRING) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_trust_level(&self, ptr_trust_level: LPVOID) -> HRESULT;
+
+    /* IApplicationView methods */
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub fn set_focus(&self) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub fn switch_to(&self) -> HRESULT;
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn try_invoke_back(&self, ptr_async_callback: IAsyncCallback) -> HRESULT;
+    pub fn get_thumbnail_window(&self, out_hwnd: &mut HWND) -> HRESULT {
+        unsafe { IApplicationView!(self, |i| i.get_thumbnail_window(out_hwnd)) }
+    }
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_monitor(&self, out_monitors: *mut *mut IImmersiveMonitor) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_visibility(&self, out_int: LPVOID) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_cloak(
+        &self,
+        application_view_cloak_type: APPLICATION_VIEW_CLOAK_TYPE,
+        unknown: INT,
+    ) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_position(
+        &self,
+        unknowniid: *const GUID,
+        unknown_array_ptr: LPVOID,
+    ) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_position(&self, view_position: *mut IApplicationViewPosition) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn insert_after_window(&self, window: HWND) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_extended_frame_position(&self, rect: *mut RECT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_app_user_model_id(&self, id: *mut PWSTR) -> HRESULT; // Proc17
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_app_user_model_id(&self, id: PCWSTR) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn is_equal_by_app_user_model_id(&self, id: PCWSTR, out_result: *mut INT)
+        -> HRESULT;
+
+    /*** IApplicationView methods ***/
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_view_state(&self, out_state: *mut UINT) -> HRESULT; // Proc20
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_view_state(&self, state: UINT) -> HRESULT; // Proc21
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_neediness(&self, out_neediness: *mut INT) -> HRESULT; // Proc22
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_last_activation_timestamp(&self, out_timestamp: *mut ULONGLONG) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_last_activation_timestamp(&self, timestamp: ULONGLONG) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_virtual_desktop_id(&self, out_desktop_guid: *mut GUID) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_virtual_desktop_id(&self, desktop_guid: *const GUID) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_show_in_switchers(&self, out_show: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_show_in_switchers(&self, show: INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_scale_factor(&self, out_scale_factor: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn can_receive_input(&self, out_can: *mut BOOL) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_compatibility_policy_type(
+        &self,
+        out_policy_type: *mut APPLICATION_VIEW_COMPATIBILITY_POLICY,
+    ) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_compatibility_policy_type(
+        &self,
+        policy_type: APPLICATION_VIEW_COMPATIBILITY_POLICY,
+    ) -> HRESULT;
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_size_constraints(
+        &self,
+        monitor: *mut IImmersiveMonitor,
+        out_size1: *mut SIZE,
+        out_size2: *mut SIZE,
+    ) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_size_constraints_for_dpi(
+        &self,
+        dpi: UINT,
+        out_size1: *mut SIZE,
+        out_size2: *mut SIZE,
+    ) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn set_size_constraints_for_dpi(
+        &self,
+        dpi: *const UINT,
+        size1: *const SIZE,
+        size2: *const SIZE,
+    ) -> HRESULT;
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn on_min_size_preferences_updated(&self, window: HWND) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn apply_operation(&self, operation: *mut IApplicationViewOperation) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn is_tray(&self, out_is: *mut BOOL) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn is_in_high_zorder_band(&self, out_is: *mut BOOL) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn is_splash_screen_presented(&self, out_is: *mut BOOL) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn flash(&self) -> HRESULT;
+    pub unsafe fn get_root_switchable_owner(&self, app_view: *mut IApplicationView) -> HRESULT {
+        // proc45
+        IApplicationView!(self, |inner| inner
+            .get_root_switchable_owner(app_view as *mut _))
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn enumerate_ownership_tree(&self, objects: *mut IObjectArray) -> HRESULT; // proc46
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn get_enterprise_id(&self, out_id: *mut PWSTR) -> HRESULT; // proc47
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn is_mirrored(&self, out_is: *mut BOOL) -> HRESULT; //
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown1(&self, arg: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown2(&self, arg: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown3(&self, arg: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown4(&self, arg: INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown5(&self, arg: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown6(&self, arg: INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown7(&self) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown8(&self, arg: *mut INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown9(&self, arg: INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown10(&self, arg: INT, arg2: INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown11(&self, arg: INT) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IApplicationView]
+    pub unsafe fn unknown12(&self, arg: *mut SIZE) -> HRESULT;
+}
+
+support_interface!(as IVirtualDesktopInner for IVirtualDesktop in [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IVirtualDesktop(IUnknown);
+impl IVirtualDesktop {
+    pub fn is_view_visible(&self, p_view: &IApplicationView, out_bool: &mut u32) -> HRESULT {
+        unsafe { IVirtualDesktop!(self, |inner| inner.is_view_visible(p_view.into(), out_bool)) }
+    }
+    pub fn get_id(&self, out_guid: &mut GUID) -> HRESULT {
+        unsafe { IVirtualDesktop!(self, |inner| inner.get_id(out_guid)) }
+    }
+
+    pub fn get_name(&self, out_string: &mut HSTRING) -> HRESULT {
+        match IVirtualDesktopInner::from_typed(self) {
+            IVirtualDesktopInner::build_10240(_) => E_NOTIMPL,
+            IVirtualDesktopInner::build_22000(this) => unsafe { this.get_name(out_string) },
+        }
+    }
+    pub fn get_wallpaper(&self, out_string: &mut HSTRING) -> HRESULT {
+        match IVirtualDesktopInner::from_typed(self) {
+            IVirtualDesktopInner::build_10240(_) => E_NOTIMPL,
+            IVirtualDesktopInner::build_22000(this) => unsafe { this.get_wallpaper(out_string) },
+        }
+    }
+}
+
+support_interface!(as IApplicationViewCollectionInner for IApplicationViewCollection in all [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IApplicationViewCollection(IUnknown);
+impl IApplicationViewCollection {
+    #[apply(forward_call)]
+    #[forward_for = IApplicationViewCollection]
+    pub unsafe fn get_views(&self, out_views: *mut IObjectArray) -> HRESULT;
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationViewCollection]
+    pub unsafe fn get_views_by_zorder(&self, out_views: *mut IObjectArray) -> HRESULT;
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationViewCollection]
+    pub unsafe fn get_views_by_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_views: *mut IObjectArray,
+    ) -> HRESULT;
+
+    pub unsafe fn get_view_for_hwnd(
+        &self,
+        window: HWND,
+        out_view: *mut Option<IApplicationView>,
+    ) -> HRESULT {
+        IApplicationViewCollection!(self, |inner| inner
+            .get_view_for_hwnd(window, out_view as *mut _))
+    }
+
+    pub unsafe fn get_view_for_application(
+        &self,
+        app: IImmersiveApplication,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT {
+        IApplicationViewCollection!(self, |inner| inner
+            .get_view_for_application(app, out_view as *mut _))
+    }
+
+    pub unsafe fn get_view_for_app_user_model_id(
+        &self,
+        id: PCWSTR,
+        out_view: *mut IApplicationView,
+    ) -> HRESULT {
+        IApplicationViewCollection!(self, |inner| inner
+            .get_view_for_app_user_model_id(id, out_view as *mut _))
+    }
+
+    pub fn get_view_in_focus(&self, out_view: &mut Option<IApplicationView>) -> HRESULT {
+        unsafe {
+            IApplicationViewCollection!(self, |inner| inner
+                .get_view_in_focus(out_view as *mut Option<_> as *mut _))
+        }
+    }
+
+    pub fn try_get_last_active_visible_view(
+        &self,
+        out_view: &mut Option<IApplicationView>,
+    ) -> HRESULT {
+        unsafe {
+            match IApplicationViewCollectionInner::from_typed(self) {
+                IApplicationViewCollectionInner::build_10240(_) => E_NOTIMPL,
+                IApplicationViewCollectionInner::build_22000(this) => {
+                    this.try_get_last_active_visible_view(out_view as *mut Option<_> as *mut _)
+                }
+            }
+        }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationViewCollection]
+    pub unsafe fn refresh_collection(&self) -> HRESULT;
+
+    pub fn register_for_application_view_changes(
+        &self,
+        listener: IApplicationViewChangeListener,
+        out_id: &mut DWORD,
+    ) -> HRESULT {
+        unsafe {
+            IApplicationViewCollection!(self, |inner| inner
+                .register_for_application_view_changes(listener, out_id))
+        }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IApplicationViewCollection]
+    pub fn unregister_for_application_view_changes(&self, id: DWORD) -> HRESULT;
+}
+
+support_interface!(as IVirtualDesktopNotificationInner for IVirtualDesktopNotification in all [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IVirtualDesktopNotification(IUnknown);
+impl IVirtualDesktopNotification {
+    pub fn as_raw(&self) -> *mut c_void {
+        self.0.as_raw()
+    }
+}
+impl<T> From<T> for IVirtualDesktopNotification
+where
+    T: IVirtualDesktopNotification_Impl,
+{
+    fn from(value: T) -> Self {
+        match WindowsVersion::get() {
+            WindowsVersion::Build10240 => build_10240::IVirtualDesktopNotification::from(
+                build_10240::VirtualDesktopNotificationAdaptor { inner: value },
+            )
+            .into(),
+            WindowsVersion::Build22000 => build_22000::IVirtualDesktopNotification::from(
+                build_22000::VirtualDesktopNotificationAdaptor { inner: value },
+            )
+            .into(),
+        }
+    }
+}
+#[allow(non_camel_case_types)]
+pub trait IVirtualDesktopNotification_Impl {
+    fn virtual_desktop_created(&self, desktop: &IVirtualDesktop) -> HRESULT;
+
+    fn virtual_desktop_destroy_begin(
+        &self,
+        desktop_destroyed: &IVirtualDesktop,
+        desktop_fallback: &IVirtualDesktop,
+    ) -> HRESULT;
+
+    fn virtual_desktop_destroy_failed(
+        &self,
+        desktop_destroyed: &IVirtualDesktop,
+        desktop_fallback: &IVirtualDesktop,
+    ) -> HRESULT;
+
+    fn virtual_desktop_destroyed(
+        &self,
+        desktop_destroyed: &IVirtualDesktop,
+        desktop_fallback: &IVirtualDesktop,
+    ) -> HRESULT;
+
+    fn virtual_desktop_moved(
+        &self,
+        desktop: &IVirtualDesktop,
+        old_index: i64,
+        new_index: i64,
+    ) -> HRESULT;
+
+    fn virtual_desktop_name_changed(&self, desktop: &IVirtualDesktop, name: HSTRING) -> HRESULT;
+
+    fn view_virtual_desktop_changed(&self, view: &IApplicationView) -> HRESULT;
+
+    fn current_virtual_desktop_changed(
+        &self,
+        desktop_old: &IVirtualDesktop,
+        desktop_new: &IVirtualDesktop,
+    ) -> HRESULT;
+
+    fn virtual_desktop_wallpaper_changed(
+        &self,
+        desktop: &IVirtualDesktop,
+        name: HSTRING,
+    ) -> HRESULT;
+
+    fn virtual_desktop_switched(&self, desktop: &IVirtualDesktop) -> HRESULT;
+
+    fn remote_virtual_desktop_connected(&self, desktop: &IVirtualDesktop) -> HRESULT;
+}
+
+support_interface!(as IVirtualDesktopNotificationServiceInner for IVirtualDesktopNotificationService in all [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IVirtualDesktopNotificationService(IUnknown);
+
+impl IVirtualDesktopNotificationService {
+    pub fn register(
+        &self,
+        notification: &IVirtualDesktopNotification,
+        out_cookie: &mut DWORD,
+    ) -> HRESULT {
+        unsafe {
+            IVirtualDesktopNotificationService!(self, |inner| inner
+                .register(notification.as_raw(), out_cookie))
+        }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopNotificationService]
+    pub fn unregister(&self, cookie: u32) -> HRESULT;
+}
+
+support_interface!(as IVirtualDesktopManagerInternalInner for IVirtualDesktopManagerInternal in all [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IVirtualDesktopManagerInternal(IUnknown);
+impl IVirtualDesktopManagerInternal {
+    pub fn get_desktop_count(&self, out_count: &mut UINT) -> HRESULT {
+        unsafe { IVirtualDesktopManagerInternal!(self, |i| i.get_desktop_count(out_count)) }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn move_view_to_desktop(
+        &self,
+        view: &IApplicationView,
+        desktop: &IVirtualDesktop,
+    ) -> HRESULT;
+
+    pub fn can_move_view_between_desktops(
+        &self,
+        view: &IApplicationView,
+        can_move: &mut i32,
+    ) -> HRESULT {
+        unsafe {
+            IVirtualDesktopManagerInternal!(self, |i| i
+                .can_move_view_between_desktops(view.into(), can_move))
+        }
+    }
+
+    pub fn get_current_desktop(&self, out_desktop: &mut Option<IVirtualDesktop>) -> HRESULT {
+        unsafe {
+            IVirtualDesktopManagerInternal!(self, |inner| {
+                inner.get_current_desktop(out_desktop as *mut Option<_> as *mut Option<_>)
+            })
+        }
+    }
+
+    pub fn get_desktops(&self, out_desktops: &mut Option<IObjectArray>) -> HRESULT {
+        unsafe { IVirtualDesktopManagerInternal!(self, |inner| inner.get_desktops(out_desktops)) }
+    }
+
+    /// Get next or previous desktop
+    ///
+    /// Direction values:
+    /// 3 = Left direction
+    /// 4 = Right direction
+    pub fn get_adjacent_desktop(
+        &self,
+        in_desktop: &IVirtualDesktop,
+        direction: UINT,
+        out_pp_desktop: &mut Option<IVirtualDesktop>,
+    ) -> HRESULT {
+        unsafe {
+            IVirtualDesktopManagerInternal!(self, |inner| inner.get_adjacent_desktop(
+                in_desktop.into(),
+                direction,
+                out_pp_desktop as *mut Option<_> as *mut Option<_>,
+            ))
+        }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn switch_desktop(&self, desktop: &IVirtualDesktop) -> HRESULT;
+
+    pub fn create_desktop(&self, out_desktop: &mut Option<IVirtualDesktop>) -> HRESULT {
+        unsafe {
+            IVirtualDesktopManagerInternal!(self, |inner| inner
+                .create_desktop(out_desktop as *mut Option<_> as *mut Option<_>))
+        }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn move_desktop(&self, in_desktop: &IVirtualDesktop, index: UINT) -> HRESULT;
+
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn remove_desktop(
+        &self,
+        destroy_desktop: &IVirtualDesktop,
+        fallback_desktop: &IVirtualDesktop,
+    ) -> HRESULT;
+
+    pub fn find_desktop(&self, guid: &GUID, out_desktop: &mut Option<IVirtualDesktop>) -> HRESULT {
+        unsafe {
+            IVirtualDesktopManagerInternal!(self, |inner| {
+                inner.find_desktop(guid, out_desktop as *mut Option<_> as *mut Option<_>)
+            })
+        }
+    }
+
+    pub fn get_desktop_switch_include_exclude_views(
+        &self,
+        desktop: &IVirtualDesktop,
+        out_pp_desktops1: &mut Option<IObjectArray>,
+        out_pp_desktops2: &mut Option<IObjectArray>,
+    ) -> HRESULT {
+        unsafe {
+            IVirtualDesktopManagerInternal!(self, |inner| inner
+                .get_desktop_switch_include_exclude_views(
+                    desktop.into(),
+                    out_pp_desktops1 as *mut Option<_> as *mut _,
+                    out_pp_desktops2 as *mut Option<_> as *mut _
+                ))
+        }
+    }
+
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn set_name(&self, desktop: &IVirtualDesktop, name: HSTRING) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn set_wallpaper(&self, desktop: &IVirtualDesktop, name: HSTRING) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopManagerInternal]
+    pub fn update_wallpaper_for_all(&self, name: HSTRING) -> HRESULT;
+}
+
+support_interface!(as IVirtualDesktopPinnedAppsInner for IVirtualDesktopPinnedApps in all [build_10240, build_22000]);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct IVirtualDesktopPinnedApps(IUnknown);
+
+impl IVirtualDesktopPinnedApps {
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopPinnedApps]
+    pub unsafe fn is_app_pinned(&self, app_id: PCWSTR, out_iss: *mut bool) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopPinnedApps]
+    pub unsafe fn pin_app(&self, app_id: PCWSTR) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopPinnedApps]
+    pub unsafe fn unpin_app(&self, app_id: PCWSTR) -> HRESULT;
+
+    pub fn is_view_pinned(&self, view: &IApplicationView, out_iss: &mut bool) -> HRESULT {
+        unsafe {
+            IVirtualDesktopPinnedApps!(self, |inner| inner.is_view_pinned(view.into(), out_iss))
+        }
+    }
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopPinnedApps]
+    pub fn pin_view(&self, view: &IApplicationView) -> HRESULT;
+    #[apply(forward_call)]
+    #[forward_for = IVirtualDesktopPinnedApps]
+    pub fn unpin_view(&self, view: &IApplicationView) -> HRESULT;
+}
+
+// Bellow are helper methods that accesses the real COM interfaces. We could
+// avoid the need for these helper methods by working with the IUnknown
+// interface or implementing ComInterface for our abstraction types with the
+// `IUnknown` IDD, even if that might get confusing.
+
+struct IObjectArrayGetAtCallback<'a, T>(&'a IObjectArray, UINT, PhantomData<T>);
+impl<COM, T> WithVersionedTypeCallback<COM, Result<T, windows::core::Error>>
+    for IObjectArrayGetAtCallback<'_, T>
+where
+    // The COM interface for this specific Windows version:
+    COM: ComInterface,
+    // Should be possible to convert it into the more generic type:
+    T: From<COM>,
+{
+    fn call(self) -> Result<T, windows::core::Error> {
+        let com: COM = unsafe { self.0.GetAt::<COM>(self.1)? };
+        Ok(From::from(com))
+    }
+}
+
+/// Same as `GetAt` for `IObjectArray` but works even when we don't know the IID
+/// of a COM interface at compile time.
+#[allow(non_snake_case, private_bounds)]
+pub unsafe fn IObjectArrayGetAt<'a, T>(
+    object_array: &'a IObjectArray,
+    index: UINT,
+) -> Result<T, windows::core::Error>
+where
+    T: WithVersionedType<IObjectArrayGetAtCallback<'a, T>, Result<T, windows::core::Error>>,
+{
+    T::with_versioned_type(IObjectArrayGetAtCallback(object_array, index, PhantomData))
+        .ok_or_else(|| windows::core::Error::from(E_NOTIMPL))?
+}


### PR DESCRIPTION
This PR detects the Windows build version at runtime and selects different COM interfaces based on it. This allows us to support both Windows 10 and Windows 11 at the same time.

I have not tested this thoroughly so there might be bugs but it seems to work on Windows 10. I don't have Windows 11 so don't know if it works there but I think it should.